### PR TITLE
chore: Document synced package name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
-# Keep in sync with `PACKAGE` in `Makefile`
+# Keep in sync with both
+# - `acapPackageConf.setup.appName` in `manifest.json`
+# - `PACKAGE` in `Makefile`
 name = "licensekey_handler"
 version = "1.0.0"
 edition = "2021"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@
 # Name of package containing the app to be built.
 # Rust does not enforce that the path to the package matches the package name, but
 # this makefile does to keep things simple.
-# Keep in sync with `package.name` from `Cargo.toml`
+# Keep in sync with both
+# - `acapPackageConf.setup.appName` in `manifest.json`
+# - `package.name` in `Cargo.toml`
 PACKAGE ?= licensekey_handler
 
 # The architecture that will be assumed when interacting with the device.


### PR DESCRIPTION
If the name is not kept in sync, building the app will not work and the error message may not be useful depending on experience.