### PR TITLE
Generate `LICENSE` file

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: cargo install cross
+        run: |
+          cargo install cross
+          cargo install --locked cargo-about@0.6.2
       - name: Run checks
         run: |
           make --always-make check_all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@
 name = "hello_world"
 version = "1.0.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 log = "0.4.21"

--- a/Makefile
+++ b/Makefile
@@ -153,9 +153,12 @@ target/%/$(PACKAGE)/manifest.json: manifest.json
 	mkdir -p $(dir $@)
 	cp $< $@
 
-target/%/$(PACKAGE)/LICENSE: LICENSE
+target/%/$(PACKAGE)/LICENSE: Cargo.toml about.hbs
 	mkdir -p $(dir $@)
-	cp $< $@
+	cargo-about generate \
+		--manifest-path Cargo.toml \
+		--output-file $@ \
+		about.hbs
 
 # The target triple and the name of the docker image do not match, so
 # at some point we need to map one to the other. It might as well be here.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Ensure global prerequisites are installed:
 * Docker
 * Rust e.g. [using rustup](https://www.rust-lang.org/tools/install)
 * Cross e.g. like `cargo install cross`
+* `cargo-about` e.g. like `cargo install --locked cargo-about@0.6.2`
 
 Build the app and create `.eap` files in the `target/acap/` directory like:
 

--- a/about.hbs
+++ b/about.hbs
@@ -1,0 +1,12 @@
+
+Third Party Software Licenses
+
+
+{{#each licenses}}
+{{#each used_by}}
+Software license for {{{crate.name}}} {{{crate.version}}}
+
+{{{../text}}}
+
+{{/each}}
+{{/each}}

--- a/about.toml
+++ b/about.toml
@@ -1,0 +1,7 @@
+accepted = [
+    "MIT",
+    "Apache-2.0",
+]
+ignore-build-dependencies = true
+ignore-dev-dependencies = true
+private = { ignore = true }


### PR DESCRIPTION
In `Cargo.toml`:
* Set `package.publish` to avoid warnings when generating license files. This also helps clarify and enforce the intention that these crates will not be published.

In `about.hbs`:
* Replace the default html-generating template with one that generates a text file that is superficially similar to the file published with Axis OS.

In `about.toml`:
* List `MIT` before `Apache-2.0` because the former is more permissive.
* Set `ignore-build-dependencies` and `ignore-dev-dependencies` because afaik only code that is actually included in the distributed artifact need to be declared and without these set the list of accepted licenses would have a handful of additional elements.

In `README.md`:
* Use `cargo install` with the `--locked` option because the authors recommend it and I too value reproducibility.
* Specify version 0.6.2 to improve reproducibility; this is the latest version as of writing.

In `Makefile`:
* Run `cargo-about` with the `--manifest-path` even though this is redundant to emphasize the dependency and why `Cargo.toml` is listed as a prerequisite.