### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.4.3",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:e9e1d402031416ed5fc500f242c27ffa1043a27b5ba612e6596ea62503c8ae70",
+      "integrity": "sha256:e9e1d402031416ed5fc500f242c27ffa1043a27b5ba612e6596ea62503c8ae70"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+    "name": "acap-rs-app-template",
+    "build": {
+        "dockerfile": "../Dockerfile",
+        "context": ".."
+    },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {},
+    },
+    "remoteUser": "${localEnv:USER}",
+    "containerEnv": {
+        "CARGO_HOME": "/home/${localEnv:USER}/.cargo"
+    }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
           - "minor"
           - "patch"
     versioning-strategy: lockfile-only
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG REPO=axisecp
 ARG SDK=acap-native-sdk
 ARG UBUNTU_VERSION=22.04
 ARG VERSION=1.14
-ARG BASE_IMAGE=debian:bookworm-20240423-slim
+ARG BASE_IMAGE=debian:bookworm-20240423
 
 FROM ${REPO}/${SDK}:${VERSION}-aarch64-ubuntu${UBUNTU_VERSION} AS sdk-aarch64
 FROM ${REPO}/${SDK}:${VERSION}-armv7hf-ubuntu${UBUNTU_VERSION} AS sdk-armv7hf

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ To contribute to the crates that this template uses, please see [acap-rs](https:
 
 ## Quickstart guide
 
-Build the `hello_world` example and create `.eap` files in the `target/acap/` directory like
+The quickest way to build this example is to launch the dev container and run:
+
+```sh
+make build
+```
+
+If you prefer to not use dev containers, or the implementation in your favorite IDE is buggy, you can accomplish the same thing using `docker`:
 
 ```sh
 docker build --tag acap-rs-app-template .
@@ -21,11 +27,9 @@ docker run \
   --user $(id -u):$(id -g) \
   --volume $(pwd):$(pwd) \
   --workdir $(pwd) \
-  acap-rs \
-  make build PACKAGE=hello_world
+  acap-rs-app-template \
+  make build
 ```
-
-This works with any of the [example applications](#example-applications).
 
 ## Advanced setup
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ To contribute to the crates that this template uses, please see [acap-rs](https:
 
 ## Quickstart guide
 
-The quickest way to build this example is to launch the dev container and run:
+The quickest way to build this example is to launch the dev container and run `make build`.
+Once it completes there should be two `.eap` files in `target/acap`:
 
-```sh
-make build
+```console
+$ ls -1 target/acap
+hello_world_1_0_0_aarch64.eap
+hello_world_1_0_0_armv7hf.eap
 ```
 
-If you prefer to not use dev containers, or the implementation in your favorite IDE is buggy, you can accomplish the same thing using `docker`:
+If you prefer to not use dev containers, or the implementation in your favorite IDE is buggy, the app can be built using only `docker`:
 
 ```sh
 docker build --tag acap-rs-app-template .


### PR DESCRIPTION
`devcontainer-lock.json` is created like:
`devcontainer build --workspace-path . --experimental-lockfile`

In `devcontainer.json`:
- `name` is set to match the name of this project because that seems like a reasonable way to help users understand what context they are working in.
- `build` is set to use the existing `Dockerfile`
- `features` is set to use `common-utils` because this seems to be required to get `remoteUser` to work.
- `remoteUser` is set to the local user because without it files created are owned by root. This surprises me because from the docs I got the impression that dev containers would ensure permissions are mapped in a sensible way by default.
- `containerEnv` is set to overwrite `CARGO_HOME` because it is set in the image causing `cargo` to use a directory that is owned by root instead of the default directory.

In `Dockerfile`:
- `-slim` is removed from the base image to include common utilities in the dev container. The `Dockerfile` was originally added to show how apps could be built in a CI pipeline that uses containers but I think it is more important to make it easy for developers to get started using the template. Besides, the resulting image can still be used in CI, it is just a bit bulkier.

In `README.md`:
- The compatibility with dev containers is mentioned to raise awareness among potential users.
- The remaining part of the quickstart guide are tweaked to fit this template; a recent commit ported some changes from acap-rs in bad way.