### PR TITLE
chore: Specify exact version of `cross`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: cargo install cross
+        run: cargo install --locked cross@0.2.5
       - name: Run checks
         run: |
           make --always-make check_all

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Ensure global prerequisites are installed:
 
 * Docker
 * Rust e.g. [using rustup](https://www.rust-lang.org/tools/install)
-* Cross e.g. like `cargo install cross`
+* Cross e.g. like `cargo install --locked cross@0.2.5`
 
 Useful workflows are documented under the "Verbs" section of the [Makefile](./Makefile).
 If Python package `mkhelp==0.2.1` is installed, they can be summarized like:


### PR DESCRIPTION
Using the `--locked` option and specifying a specific version will hopefully have two effects:
- the setup that worked when the code was committed will work also for other users.
- if a user experiences a problem, it will be easier to establish if the environment is a likely cause.

### Describe your changes

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
