### PR TITLE
Source app-logging from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "acap-logging"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0609ee4b4fc001e913cfb10ebee12674ad0faa909b3af3510271962297bbcd6"
+dependencies = [
+ "env_logger",
+ "log",
+ "syslog",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,16 +72,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "app-logging"
-version = "0.0.0"
-source = "git+https://github.com/AxisCommunications/acap-rs.git#1c5083e41134644d2411f4e91551047c04902393"
-dependencies = [
- "env_logger",
- "log",
- "syslog",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,7 +122,7 @@ dependencies = [
 name = "hello_world"
 version = "1.0.0"
 dependencies = [
- "app-logging",
+ "acap-logging",
  "log",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ version = "1.0.0"
 edition = "2021"
 
 [dependencies]
+acap-logging = "0.0.0"
 log = "0.4.21"
 
-app-logging = { git = "https://github.com/AxisCommunications/acap-rs.git", ref="9dec3688b02dd72884d32d455c0831113f9a2771" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,6 @@
 use log::info;
 
 fn main() {
-    app_logging::init_logger();
+    acap_logging::init_logger();
     info!("Hello World!");
 }


### PR DESCRIPTION
Originally part of my intent was to demonstrate how library crates from acap-rs can be used before they are published, but now I'm thinking:
- it is annoying that dependabot bumps the rev every week that there is a new commit in acap-rs.
- developers looking for a bleeding edge experience should be familiar enough with Rust to figure this our on their own.
