### PR TITLE
Change package and app version to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "hello_world"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "acap-logging",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
-# Keep in sync with both
+# Keep in sync with:
 # - `acapPackageConf.setup.appName` in `manifest.json`
 # - `PACKAGE` in `Makefile`
 name = "hello_world"
-version = "1.0.0"
+# Keep in sync with:
+# - `acapPackageConf.setup.version` in `manifest.json`
+version = "0.1.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Once it completes there should be two `.eap` files in `target/acap`:
 
 ```console
 $ ls -1 target/acap
-hello_world_1_0_0_aarch64.eap
-hello_world_1_0_0_armv7hf.eap
+hello_world_0_1_0_aarch64.eap
 ```
 
 Useful workflows are documented under the "Verbs" section of the [Makefile](./Makefile).

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
             "appName": "hello_world",
             "vendor": "Axis Communications",
             "runMode": "never",
-            "version": "1.0.0"
+            "version": "0.1.0"
         }
     }
 }


### PR DESCRIPTION
Apps based on this will likely undergo a period of initial development with frequent, breaking changes, so starting on version 1 does not make much sense. `0.1.0` was chosen because that is the version that crates created with `cargo new` get.

`Makefile`:
- Update expected output from `ls`; acap-rs changed the behavior of `build` some time ago to build only for the selected architecture and when adopting these changes I forgot to also update the READEM.
