### PR TITLE
Update tools from acap-rs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,6 +38,7 @@ ENV PATH=/usr/local/cargo/bin:$PATH \
     RUSTUP_HOME=/usr/local/rustup
 
 COPY rust-toolchain.toml ./
+# Consider using `--rev` with a commit ID instead of a tag to protect against supply chain attacks.
 RUN curl \
     --output /tmp/rustup-init \
     "https://static.rust-lang.org/rustup/archive/1.26.0/x86_64-unknown-linux-gnu/rustup-init" \
@@ -53,7 +54,7 @@ RUN curl \
   && cargo install \
      --locked \
      --git https://github.com/AxisCommunications/acap-rs.git \
-     --rev 5148b09e77e321a215a18f2f4ab75ec64839265c \
+     --rev cargo-acap-sdk-v0.2.0 \
      acap-ssh-utils \
      cargo-acap-build \
      cargo-acap-sdk \

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Commands:
   run          Build app(s) and run on the device
   test         Build app(s) in test mode and run on the device
   install      Build app(s) with release profile and install on the device
+  start        Start app on device
+  stop         Stop app on device
+  restart      Restart app on device
+  remove       Remove app form device
   completions  Print shell completion script for this program
   help         Print this message or the help of the given subcommand(s)
 ```


### PR DESCRIPTION
Use a tag instead of a commit ID to make it easier for users to know and communicate what version they are on. One downside of this is that the supply chain is more vulnerable since the tags can be moved.

Use the same tag for all programs because the other programs don't yet have their own tags.