### PR TITLE
fix: Install `ssh` in container image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
     libssl-dev \
     pkg-config \
     python3-jsonschema \
+    ssh \
     sshpass
 
 ENV PATH=/usr/local/cargo/bin:$PATH \


### PR DESCRIPTION
It seems this is automatically installed when building it as a dev-container with VS Code, so most users should not be affected, but users deciding to launch the container manually would encounter problems and poor error messages when using commands that depend on SSH.