### PR TITLE
Forbid unsafe_code by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 //! A simple hello world application
 //!
 //! This app demonstrates:


### PR DESCRIPTION
In my experience writing unsafe code is difficult and the root cause of problems are often found outside of the unsafe blocks themselves. The Rustonomicon notes that:

> Generally, the only bullet-proof way to limit the scope of unsafe
> code is at the module boundary with privacy.

By forbidding unsafe_code by default I hope to encourage developers to delegate functionality that requires unsafe code to separate crates that can hopefully be audited and used by a wider audience.